### PR TITLE
Fix url resolution with empty base url

### DIFF
--- a/lib/common-utils.ts
+++ b/lib/common-utils.ts
@@ -71,22 +71,24 @@ export const determineFinalStatus = (statuses: TestStatus[]): TestStatus | null 
 };
 
 export const getUrlWithBase = (url: string | undefined, base: string | undefined): string => {
+    if (isEmpty(base)) {
+        return url || '';
+    }
+
     try {
         const userUrl = new URL(url ?? '', base);
 
         // Manually overriding properties, because if url is absolute, the above won't work
-        if (!isEmpty(base)) {
-            const baseUrl = new URL(base as string);
+        const baseUrl = new URL(base as string);
 
-            userUrl.host = baseUrl.host;
-            userUrl.protocol = baseUrl.protocol;
-            userUrl.port = baseUrl.port;
-            userUrl.username = baseUrl.username;
-            userUrl.password = baseUrl.password;
+        userUrl.host = baseUrl.host;
+        userUrl.protocol = baseUrl.protocol;
+        userUrl.port = baseUrl.port;
+        userUrl.username = baseUrl.username;
+        userUrl.password = baseUrl.password;
 
-            for (const [key, value] of baseUrl.searchParams) {
-                userUrl.searchParams.append(key, value);
-            }
+        for (const [key, value] of baseUrl.searchParams) {
+            userUrl.searchParams.append(key, value);
         }
 
         return userUrl.href;

--- a/lib/static/components/icons/view-in-browser/index.jsx
+++ b/lib/static/components/icons/view-in-browser/index.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import {Eye, EyeSlash} from '@gravity-ui/icons';
 
 import * as actions from '../../../modules/actions';
-import {getRelativeUrl, getUrlWithBase} from '../../../../common-utils';
+import {getUrlWithBase} from '../../../../common-utils';
 
 import './index.styl';
 
@@ -41,7 +41,7 @@ class ViewInBrowser extends Component {
         return (
             <a
                 className={className}
-                href={getUrlWithBase(getRelativeUrl(suiteUrl), baseHost)}
+                href={getUrlWithBase(suiteUrl, baseHost)}
                 onClick={this.onViewInBrowser}
                 title="view in browser"
                 target="_blank"

--- a/lib/static/new-ui/components/MetaInfo/index.tsx
+++ b/lib/static/new-ui/components/MetaInfo/index.tsx
@@ -5,7 +5,7 @@ import {mapValues, isObject, omitBy, isEmpty} from 'lodash';
 import React, {ReactNode} from 'react';
 import {connect} from 'react-redux';
 
-import {isUrl, getUrlWithBase, getRelativeUrl} from '@/common-utils';
+import {isUrl, getUrlWithBase} from '@/common-utils';
 import {ResultEntity, State} from '@/static/new-ui/types/store';
 import {HtmlReporterValues} from '@/plugin-api';
 import {ReporterConfig} from '@/types';
@@ -65,10 +65,10 @@ function MetaInfoInternal(props: MetaInfoInternalProps): ReactNode {
 
     const metaInfoItemsWithResolvedUrls = metaInfoItems.map((item) => {
         if (item.label === 'url' || metaInfoBaseUrls[item.label] === 'auto') {
-            const url = getUrlWithBase(getRelativeUrl(item.content), baseHost);
+            const url = getUrlWithBase(item.content, baseHost);
             return {
                 label: item.label,
-                content: getRelativeUrl(item.content),
+                content: item.content,
                 url,
                 copyText: url
             };
@@ -104,8 +104,8 @@ function MetaInfoInternal(props: MetaInfoInternalProps): ReactNode {
     if (!hasUrlMetaInfoItem && result.suiteUrl) {
         metaInfoItemsWithResolvedUrls.push({
             label: 'url',
-            content: getRelativeUrl(result.suiteUrl),
-            url: getUrlWithBase(getRelativeUrl(result.suiteUrl), baseHost)
+            content: result.suiteUrl,
+            url: getUrlWithBase(result.suiteUrl, baseHost)
         });
     }
 

--- a/test/unit/lib/common-utils.ts
+++ b/test/unit/lib/common-utils.ts
@@ -38,9 +38,9 @@ describe('common-utils', () => {
         });
 
         it('should work without baseUrl', () => {
-            const result = getUrlWithBase('some-url', '');
+            const result = getUrlWithBase('https://github.com/some/path', '');
 
-            assert.equal(result, 'some-url');
+            assert.equal(result, 'https://github.com/some/path');
         });
     });
 


### PR DESCRIPTION
Fixes incorrect URL resolution in `getUrlWithBase` when an empty base URL is provided by removing `getRelativeUrl` calls and improving empty base handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f1a9f15-6c25-49c8-9ace-439754140c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1f1a9f15-6c25-49c8-9ace-439754140c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

